### PR TITLE
Change image ordering

### DIFF
--- a/src/screens/UserImages.tsx
+++ b/src/screens/UserImages.tsx
@@ -33,10 +33,9 @@ class UserImages extends Component<CommonProps, UserImagesState> {
   addToSources = (uri: string) => {
     AsyncStorage.getItem('sources', (err, result) => {
       const parsedResult = result ? JSON.parse(result) : [];
-      AsyncStorage.setItem(
-        'sources',
-        JSON.stringify(parsedResult.concat(uri)),
-        () => this.setState({ sources: this.state.sources.concat([uri]) })
+      parsedResult.unshift(uri);
+      AsyncStorage.setItem('sources', JSON.stringify(parsedResult), () =>
+        this.setState({ sources: parsedResult })
       );
     });
   };


### PR DESCRIPTION
It doesn’t make sense to have to scroll to see an image you just uploaded.  New images should be at the top.