### PR TITLE
The header icons were being cut off due to padding

### DIFF
--- a/src/screens/UserImages.tsx
+++ b/src/screens/UserImages.tsx
@@ -172,7 +172,7 @@ const styles = StyleSheet.create({
   chevronContainerStyle: { marginHorizontal: 8 },
   username: { fontSize: 24, marginHorizontal: 16 },
   divider: { marginVertical: 1 },
-  headerRightIcon: { padding: 16 },
+  headerRightIcon: { paddingHorizontal: 16 },
 });
 
 export default UserImages;


### PR DESCRIPTION
Removed vertical padding for the header icon so that it wouldn’t get cut off on iPhone.