### PR TITLE
Made changes due to iOS testing ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ A limited functionality Instagram Clone for personal image viewing. The applicat
 
 ### Running the app
 
+#### iOS
+
+Due to a recent policy change by Apple, Expo is no longer able to share apps across users on iOS. Therefore, to be able to use the app on iOS the source must be cloned and run on a simulator. This is less than ideal as **the camera CANNOT be acessed from the simulator**. Please see [the corresponding Medium article from Expo](https://blog.expo.io/upcoming-limitations-to-ios-expo-client-8076d01aee1a)
+
+* Clone the source
+* cd to the root directory of the app
+* Execute `yarn/npm install`
+* Execute `yarn ios`
+* Agree to run on Expo
+
+#### Android
+
 Download [the Expo Client App](http://onelink.to/jcpnyt). Once installed, you can then find the app at the following link or by scanning the provided QR code with the Expo Client App.
 
 [InstaClone on Expo](https://expo.io/@alburdet619/instaclone)
@@ -15,15 +27,6 @@ Download [the Expo Client App](http://onelink.to/jcpnyt). Once installed, you ca
 ![QR]
 
 [qr]: ./resources/images/expo_qr.png
-
-#### OR
-
-* Clone the source
-* cd to the root directory of the app
-* Execute `yarn/npm install`
-* Download the Expo Client App found above
-* Execute `yarn start`
-* Scan the QR code that is displayed in your console
 
 ---
 


### PR DESCRIPTION
iOS no longer allows Expo to share apps via a link or QR.  I updated the readme to reflect this.